### PR TITLE
Add item icon sprite

### DIFF
--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -1,7 +1,14 @@
+using UnityEngine;
+
 namespace NanikaGame
 {
     public class Item
     {
         public string Id;
+
+        /// <summary>
+        /// Sprite used when displaying this item in the UI.
+        /// </summary>
+        public Sprite Icon;
     }
 }

--- a/Assets/Scripts/ItemSlotUI.cs
+++ b/Assets/Scripts/ItemSlotUI.cs
@@ -62,13 +62,23 @@ namespace NanikaGame
             Refresh();
         }
 
-        /// <summary>Refreshes the icon visibility.</summary>
+        /// <summary>Refreshes the icon sprite and visibility.</summary>
         public void Refresh()
         {
             if (Icon == null || Container == null)
                 return;
 
-            Icon.enabled = Container.Items[Index] != null;
+            var item = Container.Items[Index];
+            if (item != null)
+            {
+                Icon.sprite = item.Icon;
+                Icon.enabled = true;
+            }
+            else
+            {
+                Icon.sprite = null;
+                Icon.enabled = false;
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
- add a `Sprite Icon` field to `Item`
- update `ItemSlotUI.Refresh` to apply the item's icon sprite when showing a slot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fb6c0b2a08330816e9b885de5cc61