### PR TITLE
Add option to disable internal item moves

### DIFF
--- a/Assets/Scripts/ItemContainer.cs
+++ b/Assets/Scripts/ItemContainer.cs
@@ -41,6 +41,12 @@ namespace NanikaGame
         public bool IsEmpty => Count == 0;
 
         /// <summary>
+        /// Gets or sets a value indicating whether items can be moved
+        /// between slots within this container.
+        /// </summary>
+        public bool AllowInternalMove { get; set; } = true;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ItemContainer"/> class
         /// with a default capacity of 5.
         /// </summary>
@@ -186,6 +192,9 @@ namespace NanikaGame
             if (!IsIndexValid(fromIndex) || !destination.IsIndexValid(toIndex))
                 return false;
 
+            if (destination == this && !AllowInternalMove)
+                return false;
+
             var item = Items[fromIndex];
             if (item == null)
                 return false;
@@ -215,6 +224,9 @@ namespace NanikaGame
                 throw new ArgumentNullException(nameof(destination));
 
             if (!IsIndexValid(fromIndex))
+                return false;
+
+            if (destination == this && !AllowInternalMove)
                 return false;
 
             var item = Items[fromIndex];

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## NanikaGame Item Container
+
+This repository contains scripts for an item container system in Unity.
+
+### ItemContainer
+
+- **AllowInternalMove**: When set to `false`, items cannot be moved between slots in the same container. This is enabled by default.


### PR DESCRIPTION
## Summary
- add `AllowInternalMove` property in `ItemContainer`
- block moves within the same container when disabled
- document property in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684fba20f41c83309140296c1f83b46b