### PR TITLE
Add item price and price slot UI

### DIFF
--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -10,5 +10,10 @@ namespace NanikaGame
         /// Sprite used when displaying this item in the UI.
         /// </summary>
         public Sprite Icon;
+
+        /// <summary>
+        /// Price of this item in game currency.
+        /// </summary>
+        public int Price;
     }
 }

--- a/Assets/Scripts/ItemSlotUI.cs
+++ b/Assets/Scripts/ItemSlotUI.cs
@@ -63,7 +63,7 @@ namespace NanikaGame
         }
 
         /// <summary>Refreshes the icon sprite and visibility.</summary>
-        public void Refresh()
+        public virtual void Refresh()
         {
             if (Icon == null || Container == null)
                 return;

--- a/Assets/Scripts/PriceItemSlotUI.cs
+++ b/Assets/Scripts/PriceItemSlotUI.cs
@@ -1,3 +1,5 @@
+using TMPro;
+using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace NanikaGame
@@ -8,26 +10,26 @@ namespace NanikaGame
     public class PriceItemSlotUI : ItemSlotUI
     {
         /// <summary>UI text used to show the item's price.</summary>
-        public Text PriceLabel;
+        public TextMeshProUGUI priceLabel;
 
         /// <inheritdoc />
         public override void Refresh()
         {
             base.Refresh();
 
-            if (PriceLabel == null || Container == null)
+            if (priceLabel == null || Container == null)
                 return;
 
             var item = Container.Items[Index];
             if (item != null)
             {
-                PriceLabel.text = item.Price.ToString();
-                PriceLabel.enabled = true;
+                priceLabel.text = item.Price.ToString();
+                priceLabel.enabled = true;
             }
             else
             {
-                PriceLabel.text = string.Empty;
-                PriceLabel.enabled = false;
+                priceLabel.text = string.Empty;
+                priceLabel.enabled = false;
             }
         }
     }

--- a/Assets/Scripts/PriceItemSlotUI.cs
+++ b/Assets/Scripts/PriceItemSlotUI.cs
@@ -1,0 +1,34 @@
+using UnityEngine.UI;
+
+namespace NanikaGame
+{
+    /// <summary>
+    /// Slot UI that displays an item's price in addition to its icon.
+    /// </summary>
+    public class PriceItemSlotUI : ItemSlotUI
+    {
+        /// <summary>UI text used to show the item's price.</summary>
+        public Text PriceLabel;
+
+        /// <inheritdoc />
+        public override void Refresh()
+        {
+            base.Refresh();
+
+            if (PriceLabel == null || Container == null)
+                return;
+
+            var item = Container.Items[Index];
+            if (item != null)
+            {
+                PriceLabel.text = item.Price.ToString();
+                PriceLabel.enabled = true;
+            }
+            else
+            {
+                PriceLabel.text = string.Empty;
+                PriceLabel.enabled = false;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains scripts for an item container system in Unity.
 
+### Item
+
+- **Price**: Integer value representing the in-game cost of the item.
+
 ### ItemContainer
 
 - **AllowInternalMove**: When set to `false`, items cannot be moved between slots in the same container. This is enabled by default.


### PR DESCRIPTION
## Summary
- add `Price` property to `Item`
- make `ItemSlotUI.Refresh` virtual
- add new `PriceItemSlotUI` that shows an item's price
- document the price field in `README`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684fbb7c1eb8833091179366b26baa65