### PR TITLE
Add AllowExternalMove option

### DIFF
--- a/Assets/Scripts/ItemContainer.cs
+++ b/Assets/Scripts/ItemContainer.cs
@@ -47,6 +47,12 @@ namespace NanikaGame
         public bool AllowInternalMove { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether this container accepts
+        /// moves from other containers.
+        /// </summary>
+        public bool AllowExternalMove { get; set; } = true;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ItemContainer"/> class
         /// with a default capacity of 5.
         /// </summary>
@@ -194,6 +200,8 @@ namespace NanikaGame
 
             if (destination == this && !AllowInternalMove)
                 return false;
+            if (destination != this && !destination.AllowExternalMove)
+                return false;
 
             var item = Items[fromIndex];
             if (item == null)
@@ -227,6 +235,8 @@ namespace NanikaGame
                 return false;
 
             if (destination == this && !AllowInternalMove)
+                return false;
+            if (destination != this && !destination.AllowExternalMove)
                 return false;
 
             var item = Items[fromIndex];

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This repository contains scripts for an item container system in Unity.
 ### ItemContainer
 
 - **AllowInternalMove**: When set to `false`, items cannot be moved between slots in the same container. This is enabled by default.
+- **AllowExternalMove**: When set to `false`, this container will not accept
+  items moved from other containers.


### PR DESCRIPTION
## Summary
- add `AllowExternalMove` property to `ItemContainer`
- block item moves from other containers when disabled
- document the new property

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850871f6cd48330b54cb9d4734f4844