### PR TITLE
Add discount support to item UI

### DIFF
--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -15,5 +15,15 @@ namespace NanikaGame
         /// Price of this item in game currency.
         /// </summary>
         public int Price;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this item is discounted.
+        /// </summary>
+        public bool IsDiscounted;
+
+        /// <summary>
+        /// Price to display when <see cref="IsDiscounted"/> is true.
+        /// </summary>
+        public int DiscountedPrice;
     }
 }

--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -25,5 +25,12 @@ namespace NanikaGame
         /// Price to display when <see cref="IsDiscounted"/> is true.
         /// </summary>
         public int DiscountedPrice;
+
+        /// <summary>
+        /// Gets the price that should be used for purchase logic.
+        /// Returns <see cref="DiscountedPrice"/> when <see cref="IsDiscounted"/> is true;
+        /// otherwise returns <see cref="Price"/>.
+        /// </summary>
+        public int EffectivePrice => IsDiscounted ? DiscountedPrice : Price;
     }
 }

--- a/Assets/Scripts/PriceItemSlotUI.cs
+++ b/Assets/Scripts/PriceItemSlotUI.cs
@@ -12,6 +12,9 @@ namespace NanikaGame
         /// <summary>UI text used to show the item's price.</summary>
         public TextMeshProUGUI priceLabel;
 
+        /// <summary>UI text used to show the discounted price.</summary>
+        public TextMeshProUGUI discountLabel;
+
         /// <inheritdoc />
         public override void Refresh()
         {
@@ -24,12 +27,37 @@ namespace NanikaGame
             if (item != null)
             {
                 priceLabel.text = item.Price.ToString();
+                if (item.IsDiscounted)
+                {
+                    priceLabel.fontStyle = FontStyles.Strikethrough;
+                    if (discountLabel != null)
+                    {
+                        discountLabel.text = item.DiscountedPrice.ToString();
+                        discountLabel.enabled = true;
+                    }
+                }
+                else
+                {
+                    priceLabel.fontStyle = FontStyles.Normal;
+                    if (discountLabel != null)
+                    {
+                        discountLabel.text = string.Empty;
+                        discountLabel.enabled = false;
+                    }
+                }
+
                 priceLabel.enabled = true;
             }
             else
             {
                 priceLabel.text = string.Empty;
+                priceLabel.fontStyle = FontStyles.Normal;
                 priceLabel.enabled = false;
+                if (discountLabel != null)
+                {
+                    discountLabel.text = string.Empty;
+                    discountLabel.enabled = false;
+                }
             }
         }
     }

--- a/Assets/Scripts/PriceItemSlotUI.cs
+++ b/Assets/Scripts/PriceItemSlotUI.cs
@@ -15,6 +15,12 @@ namespace NanikaGame
         /// <summary>UI text used to show the discounted price.</summary>
         public TextMeshProUGUI discountLabel;
 
+        /// <summary>
+        /// Parent object that contains <see cref="discountLabel"/>. This is
+        /// toggled on and off when displaying discounted items.
+        /// </summary>
+        public GameObject discountLabelParent;
+
         /// <inheritdoc />
         public override void Refresh()
         {
@@ -33,8 +39,11 @@ namespace NanikaGame
                     if (discountLabel != null)
                     {
                         discountLabel.text = item.DiscountedPrice.ToString();
-                        discountLabel.enabled = true;
                     }
+                    if (discountLabelParent != null)
+                        discountLabelParent.SetActive(true);
+                    else if (discountLabel != null)
+                        discountLabel.enabled = true;
                 }
                 else
                 {
@@ -42,8 +51,11 @@ namespace NanikaGame
                     if (discountLabel != null)
                     {
                         discountLabel.text = string.Empty;
-                        discountLabel.enabled = false;
                     }
+                    if (discountLabelParent != null)
+                        discountLabelParent.SetActive(false);
+                    else if (discountLabel != null)
+                        discountLabel.enabled = false;
                 }
 
                 priceLabel.enabled = true;
@@ -56,8 +68,11 @@ namespace NanikaGame
                 if (discountLabel != null)
                 {
                     discountLabel.text = string.Empty;
-                    discountLabel.enabled = false;
                 }
+                if (discountLabelParent != null)
+                    discountLabelParent.SetActive(false);
+                else if (discountLabel != null)
+                    discountLabel.enabled = false;
             }
         }
     }

--- a/Assets/Scripts/PriceRestrictedItemContainer.cs
+++ b/Assets/Scripts/PriceRestrictedItemContainer.cs
@@ -53,7 +53,7 @@ namespace NanikaGame
                 return true;
 
             var currentMoney = GetMoneyFunc?.Invoke() ?? 0;
-            return currentMoney >= item.Price;
+            return currentMoney >= item.EffectivePrice;
         }
 
         /// <inheritdoc />
@@ -63,7 +63,7 @@ namespace NanikaGame
                 return false;
 
             var currentMoney = GetMoneyFunc?.Invoke() ?? 0;
-            return currentMoney >= item.Price;
+            return currentMoney >= item.EffectivePrice;
         }
 
         /// <inheritdoc />
@@ -71,7 +71,7 @@ namespace NanikaGame
         {
             if (item != null && destination != this)
             {
-                UseMoneyAction?.Invoke(item.Price);
+                UseMoneyAction?.Invoke(item.EffectivePrice);
             }
         }
 
@@ -80,7 +80,7 @@ namespace NanikaGame
         {
             if (item != null && source != this)
             {
-                RefundMoneyAction?.Invoke(item.Price);
+                RefundMoneyAction?.Invoke(item.EffectivePrice);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository contains scripts for an item container system in Unity.
 - **Price**: Integer value representing the in-game cost of the item.
 - **IsDiscounted**: Indicates whether the item is currently on sale.
 - **DiscountedPrice**: Price shown when the item is discounted.
+- **EffectivePrice**: Returns `DiscountedPrice` when the item is on sale;
+  otherwise returns `Price`.
 
 ### ItemContainer
 
@@ -20,8 +22,8 @@ This repository contains scripts for an item container system in Unity.
 
 - **Money**: Current amount of currency available.
 - **GetMoneyFunc**: Optional function returning the current amount of money. When set, this is used for price checks instead of `Money`.
-- Items can only be moved *into* this container if the available money (from `GetMoneyFunc` or `Money`) is at least the item's `Price`.
-- Items can only be moved *out of* this container when `GetMoneyFunc` reports funds equal to or exceeding the item's `Price`.
+- Items can only be moved *into* this container if the available money (from `GetMoneyFunc` or `Money`) is at least the item's `EffectivePrice`.
+- Items can only be moved *out of* this container when `GetMoneyFunc` reports funds equal to or exceeding the item's `EffectivePrice`.
 - **UseMoneyAction**: Optional callback invoked with an item's price when it leaves the container. `Money` decreases by that amount.
 - **RefundMoneyAction**: Optional callback invoked with an item's price when it is returned.
   `Money` increases by that amount.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository contains scripts for an item container system in Unity.
 ### Item
 
 - **Price**: Integer value representing the in-game cost of the item.
+- **IsDiscounted**: Indicates whether the item is currently on sale.
+- **DiscountedPrice**: Price shown when the item is discounted.
 
 ### ItemContainer
 


### PR DESCRIPTION
## Summary
- add discount fields to `Item`
- show discounted price in `PriceItemSlotUI`
- document new fields in README

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850b36dde708330b6606326daefa189