### PR TITLE
Add SellingItemContainer

### DIFF
--- a/Assets/Scripts/SellingItemContainer.cs
+++ b/Assets/Scripts/SellingItemContainer.cs
@@ -8,10 +8,6 @@ namespace NanikaGame
     /// </summary>
     public class SellingItemContainer : ItemContainer
     {
-        /// <summary>
-        /// Current amount of money earned from sold items.
-        /// </summary>
-        public int Money { get; private set; }
 
         /// <summary>
         /// Containers monitored for drag events.
@@ -43,7 +39,6 @@ namespace NanikaGame
                 return;
 
             int price = GetPriceFunc?.Invoke(item) ?? item.EffectivePrice;
-            Money += price;
             AddMoneyAction?.Invoke(price);
 
             // Remove the item from this container after selling it.

--- a/Assets/Scripts/SellingItemContainer.cs
+++ b/Assets/Scripts/SellingItemContainer.cs
@@ -14,6 +14,17 @@ namespace NanikaGame
         public int Money { get; private set; }
 
         /// <summary>
+        /// Containers monitored for drag events.
+        /// </summary>
+        public ItemContainer[] WatchedContainers { get; set; } = Array.Empty<ItemContainer>();
+
+        /// <summary>
+        /// Callback that returns the selling price for a given item.
+        /// If not provided, <see cref="Item.EffectivePrice"/> is used.
+        /// </summary>
+        public Func<Item, int> GetPriceFunc { get; set; }
+
+        /// <summary>
         /// Optional callback invoked with the item's price when sold.
         /// </summary>
         public Action<int> AddMoneyAction { get; set; }
@@ -31,8 +42,9 @@ namespace NanikaGame
             if (item == null)
                 return;
 
-            Money += item.EffectivePrice;
-            AddMoneyAction?.Invoke(item.EffectivePrice);
+            int price = GetPriceFunc?.Invoke(item) ?? item.EffectivePrice;
+            Money += price;
+            AddMoneyAction?.Invoke(price);
 
             // Remove the item from this container after selling it.
             Items[index] = null;

--- a/Assets/Scripts/SellingItemContainer.cs
+++ b/Assets/Scripts/SellingItemContainer.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace NanikaGame
+{
+    /// <summary>
+    /// Item container that automatically converts received items into money.
+    /// Items disappear when added to this container.
+    /// </summary>
+    public class SellingItemContainer : ItemContainer
+    {
+        /// <summary>
+        /// Current amount of money earned from sold items.
+        /// </summary>
+        public int Money { get; private set; }
+
+        /// <summary>
+        /// Optional callback invoked with the item's price when sold.
+        /// </summary>
+        public Action<int> AddMoneyAction { get; set; }
+
+        /// <inheritdoc />
+        protected override bool CanSendItem(Item item, ItemContainer destination)
+        {
+            // Items cannot be moved out once sold.
+            return false;
+        }
+
+        /// <inheritdoc />
+        protected override void OnItemReceived(Item item, int index, ItemContainer source)
+        {
+            if (item == null)
+                return;
+
+            Money += item.EffectivePrice;
+            AddMoneyAction?.Invoke(item.EffectivePrice);
+
+            // Remove the item from this container after selling it.
+            Items[index] = null;
+        }
+    }
+}

--- a/Assets/Scripts/SellingItemSlotUI.cs
+++ b/Assets/Scripts/SellingItemSlotUI.cs
@@ -18,7 +18,10 @@ namespace NanikaGame
                 return;
 
             var dragged = DraggedSlot;
-            var item = dragged != null ? dragged.Container.Items[dragged.Index] : null;
+            Item item = null;
+            if (dragged != null && dragged.Container != Container)
+                item = dragged.Container.Items[dragged.Index];
+
             if (item != null)
             {
                 priceLabel.text = item.EffectivePrice.ToString();

--- a/Assets/Scripts/SellingItemSlotUI.cs
+++ b/Assets/Scripts/SellingItemSlotUI.cs
@@ -17,14 +17,21 @@ namespace NanikaGame
             if (priceLabel == null)
                 return;
 
+            if (!(Container is SellingItemContainer selling))
+                return;
+
             var dragged = DraggedSlot;
             Item item = null;
-            if (dragged != null && dragged.Container != Container)
+            if (dragged != null && selling.WatchedContainers != null &&
+                System.Array.IndexOf(selling.WatchedContainers, dragged.Container) >= 0)
+            {
                 item = dragged.Container.Items[dragged.Index];
+            }
 
             if (item != null)
             {
-                priceLabel.text = item.EffectivePrice.ToString();
+                int price = selling.GetPriceFunc?.Invoke(item) ?? item.EffectivePrice;
+                priceLabel.text = price.ToString();
                 priceLabel.enabled = true;
             }
             else

--- a/Assets/Scripts/SellingItemSlotUI.cs
+++ b/Assets/Scripts/SellingItemSlotUI.cs
@@ -1,0 +1,34 @@
+using TMPro;
+using UnityEngine;
+
+namespace NanikaGame
+{
+    /// <summary>
+    /// Slot UI for <see cref="SellingItemContainer"/>.
+    /// Displays the dragged item's selling price while an item is being dragged.
+    /// </summary>
+    public class SellingItemSlotUI : ItemSlotUI
+    {
+        /// <summary>Label used to show the selling price.</summary>
+        public TextMeshProUGUI priceLabel;
+
+        private void Update()
+        {
+            if (priceLabel == null)
+                return;
+
+            var dragged = DraggedSlot;
+            var item = dragged != null ? dragged.Container.Items[dragged.Index] : null;
+            if (item != null)
+            {
+                priceLabel.text = item.EffectivePrice.ToString();
+                priceLabel.enabled = true;
+            }
+            else
+            {
+                priceLabel.text = string.Empty;
+                priceLabel.enabled = false;
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ This repository contains scripts for an item container system in Unity.
 - **Money**: Tracks money earned by selling items.
 - When an item enters the container, its `EffectivePrice` is added to `Money` and the item is removed.
 - Items cannot be moved out once placed in the container.
+
+### SellingItemSlotUI
+
+- Displays the dragged item\x27s selling price while an item is being dragged.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ This repository contains scripts for an item container system in Unity.
 - **RefundMoneyAction**: Optional callback invoked with an item's price when it is returned.
   `Money` increases by that amount.
 - Swapping items with other containers is disabled by default.
+
+### SellingItemContainer
+
+- **Money**: Tracks money earned by selling items.
+- When an item enters the container, its `EffectivePrice` is added to `Money` and the item is removed.
+- Items cannot be moved out once placed in the container.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ This repository contains scripts for an item container system in Unity.
 ### SellingItemContainer
 
 - **Money**: Tracks money earned by selling items.
-- When an item enters the container, its `EffectivePrice` is added to `Money` and the item is removed.
+- **WatchedContainers**: Array of containers monitored for drag events.
+- **GetPriceFunc**: Callback used to determine the selling price of each item.
+- When an item enters the container, the price from `GetPriceFunc` (or `EffectivePrice` if not set) is added to `Money` and the item is removed.
+- **AddMoneyAction**: Optional callback invoked with the earned price.
 - Items cannot be moved out once placed in the container.
 
 ### SellingItemSlotUI
 
-- Displays the selling price of an item being dragged from another container.
+- Displays the selling price of an item being dragged from a container listed in `WatchedContainers`.
+- Uses `GetPriceFunc` from the associated <code>SellingItemContainer</code> to obtain the price.

--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ This repository contains scripts for an item container system in Unity.
 
 ### SellingItemSlotUI
 
-- Displays the dragged item\x27s selling price while an item is being dragged.
+- Displays the selling price of an item being dragged from another container.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ This repository contains scripts for an item container system in Unity.
 
 ### SellingItemContainer
 
-- **Money**: Tracks money earned by selling items.
 - **WatchedContainers**: Array of containers monitored for drag events.
 - **GetPriceFunc**: Callback used to determine the selling price of each item.
-- When an item enters the container, the price from `GetPriceFunc` (or `EffectivePrice` if not set) is added to `Money` and the item is removed.
+- When an item enters the container, the price from `GetPriceFunc` (or `EffectivePrice` if not set) is provided to `AddMoneyAction` and the item is removed.
 - **AddMoneyAction**: Optional callback invoked with the earned price.
 - Items cannot be moved out once placed in the container.
 


### PR DESCRIPTION
## Summary
- implement `SellingItemContainer` that converts incoming items to money
- document the new container in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68516f2ac36483309f012e7886387b83