### PR TITLE
Change AddMoneyAction to SellItemAction

### DIFF
--- a/Assets/Scripts/SellingItemContainer.cs
+++ b/Assets/Scripts/SellingItemContainer.cs
@@ -20,9 +20,10 @@ namespace NanikaGame
         public Func<Item, int> GetPriceFunc { get; set; }
 
         /// <summary>
-        /// Optional callback invoked with the item's price when sold.
+        /// Optional callback invoked when an item is sold.
+        /// The sold <see cref="Item"/> is provided as the argument.
         /// </summary>
-        public Action<int> AddMoneyAction { get; set; }
+        public Action<Item> SellItemAction { get; set; }
 
         /// <inheritdoc />
         protected override bool CanSendItem(Item item, ItemContainer destination)
@@ -37,8 +38,10 @@ namespace NanikaGame
             if (item == null)
                 return;
 
-            int price = GetPriceFunc?.Invoke(item) ?? item.EffectivePrice;
-            AddMoneyAction?.Invoke(price);
+            // Notify external systems that the item has been sold.
+            // Price information can be obtained via <see cref="GetPriceFunc"/> or
+            // <see cref="Item.EffectivePrice"/> if needed.
+            SellItemAction?.Invoke(item);
 
             // Remove the item from this container after selling it.
             Items[index] = null;

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This repository contains scripts for an item container system in Unity.
 
 - **WatchedContainers**: Array of containers monitored for drag events.
 - **GetPriceFunc**: Callback used to determine the selling price of each item.
-- When an item enters the container, the price from `GetPriceFunc` (or `EffectivePrice` if not set) is provided to `AddMoneyAction` and the item is removed.
-- **AddMoneyAction**: Optional callback invoked with the earned price.
+- When an item enters the container, it is passed to `SellItemAction` and then removed.
+- **SellItemAction**: Optional callback invoked when an item is sold. The item itself is supplied so the sale price can be determined using `GetPriceFunc` or `EffectivePrice`.
 - Items cannot be moved out once placed in the container.
 
 ### SellingItemSlotUI


### PR DESCRIPTION
## Summary
- rename `AddMoneyAction` to `SellItemAction`
- update selling logic to use the new callback
- document new property in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685192ca66e08330885d4e27e580f7fa