### PR TITLE
Move dragged item to earliest empty slot

### DIFF
--- a/Assets/Scripts/ItemContainerUI.cs
+++ b/Assets/Scripts/ItemContainerUI.cs
@@ -51,9 +51,20 @@ namespace NanikaGame
             var slot = ItemSlotUI.DraggedSlot;
             if (slot == null || Container == null)
                 return;
-            // Cancel the move if dropping onto the same container
+
             if (slot.Container == Container)
+            {
+                // When dropping onto empty space in the same container, move the
+                // item to the earliest available slot only if that slot is
+                // before the item's current position.
+                int emptyIndex = System.Array.IndexOf(Container.Items, null);
+                if (emptyIndex >= 0 && emptyIndex < slot.Index)
+                {
+                    slot.Container.MoveItem(Container, slot.Index, emptyIndex);
+                    slot.Refresh();
+                }
                 return;
+            }
 
             slot.Container.MoveToFirstEmptySlot(Container, slot.Index);
             slot.Refresh();


### PR DESCRIPTION
## Summary
- allow dropping an item back onto its container to move it to the earliest empty slot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a465605d4833096850b593fe575a7